### PR TITLE
Add Gemini2.x support

### DIFF
--- a/packages/agent-kit/src/adapters/gemini.test.ts
+++ b/packages/agent-kit/src/adapters/gemini.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { recursiveGeminiZodToJsonSchema } from "./gemini";
+import { recursiveGeminiZodToJsonSchema, requestParser } from "./gemini";
+import type { Gemini } from "@inngest/ai";
 
 // Utility to deep-clone objects without preserving references
 const clone = <T>(obj: T): T => {
@@ -196,5 +197,33 @@ describe("recursiveGeminiZodToJsonSchema", () => {
 
     recursiveGeminiZodToJsonSchema(input);
     expect(input).toEqual(inputClone);
+  });
+});
+
+describe("requestParser additional fields", () => {
+  test("includes optional fields when provided", () => {
+    const model = {
+      options: {
+        defaultParameters: {
+          safetySettings: [
+            { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_LOW_AND_ABOVE" },
+          ],
+          systemInstruction: "Stay safe",
+          generationConfig: { temperature: 0.1 },
+          cachedContent: "foo/bar",
+        },
+      },
+    } as unknown as Gemini.AiModel;
+
+    const req = requestParser(model, [], [], "auto");
+
+    expect(req).toHaveProperty("safetySettings");
+    expect((req as any).safety_settings).toEqual(req.safetySettings);
+    expect(req).toHaveProperty("systemInstruction");
+    expect((req as any).system_instruction).toEqual(req.systemInstruction);
+    expect(req).toHaveProperty("generationConfig");
+    expect((req as any).generation_config).toEqual(req.generationConfig);
+    expect(req).toHaveProperty("cachedContent", "foo/bar");
+    expect((req as any).cached_content).toEqual("foo/bar");
   });
 });

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -17,7 +17,7 @@ import { type Tool } from "../tool";
  * Parse a request from internal network messages to an Gemini input.
  */
 export const requestParser: AgenticModel.RequestParser<Gemini.AiModel> = (
-  _model,
+  model,
   messages,
   tools,
   tool_choice = "auto"
@@ -33,19 +33,56 @@ export const requestParser: AgenticModel.RequestParser<Gemini.AiModel> = (
         (geminiZodToJsonSchema(z.object({})) as any),
   }));
 
-  return {
+  const request: AiAdapter.Input<Gemini.AiModel> = {
     contents,
     ...(tools.length > 0
-      ? {
-          tools: [
-            {
-              functionDeclarations,
-            },
-          ],
-          tool_config: toolChoice(tool_choice),
-        }
+      ? (() => {
+          const config = toolChoice(tool_choice);
+          return {
+            tools: [
+              {
+                functionDeclarations,
+              },
+            ],
+            toolConfig: config,
+            // Keep backwards compatibility with Gemini 1.x which expects
+            // snake_case field names.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...( { tool_config: config } as any ),
+          };
+        })()
       : {}),
   };
+
+  const defaults = model.options?.defaultParameters ?? {};
+
+  if (defaults.safetySettings) {
+    request.safetySettings = defaults.safetySettings as unknown as AiAdapter.Input<Gemini.AiModel>["safetySettings"];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (request as any).safety_settings = request.safetySettings;
+  }
+
+  if (defaults.systemInstruction) {
+    const instr = typeof defaults.systemInstruction === "string"
+      ? { role: "system", parts: [{ text: defaults.systemInstruction }]} : defaults.systemInstruction;
+    request.systemInstruction = instr as AiAdapter.Input<Gemini.AiModel>["systemInstruction"];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (request as any).system_instruction = request.systemInstruction;
+  }
+
+  if (defaults.generationConfig) {
+    request.generationConfig = defaults.generationConfig as AiAdapter.Input<Gemini.AiModel>["generationConfig"];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (request as any).generation_config = request.generationConfig;
+  }
+
+  if (defaults.cachedContent) {
+    request.cachedContent = defaults.cachedContent as AiAdapter.Input<Gemini.AiModel>["cachedContent"];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (request as any).cached_content = request.cachedContent;
+  }
+
+  return request;
 };
 
 const messageContentToString = (content: string | TextContent[]): string => {


### PR DESCRIPTION
## Summary
- support additional Gemini request parameters
- include safety, system instruction, generation config in request parser
- test request parser optional fields

## Testing
- `pnpm --filter @inngest/agent-kit exec vitest run`

------
https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference